### PR TITLE
[Android] Fix click_activity: FCM_PLUGIN_ACTIVITY exception

### DIFF
--- a/src/android/FCMPluginActivity.java
+++ b/src/android/FCMPluginActivity.java
@@ -4,15 +4,12 @@ import android.app.Activity;
 import android.app.NotificationManager;
 import android.content.Context;
 import android.content.Intent;
-import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
-import android.preference.PreferenceManager;
-import android.support.v4.content.LocalBroadcastManager;
 import android.util.Log;
 
-import java.util.Map;
 import java.util.HashMap;
+import java.util.Map;
 
 public class FCMPluginActivity extends Activity {
     private static String TAG = "FCMPlugin";
@@ -33,7 +30,7 @@ public class FCMPluginActivity extends Activity {
 			Log.d(TAG, "==> USER TAPPED NOTFICATION");
 			data.put("wasTapped", true);
 			for (String key : getIntent().getExtras().keySet()) {
-                String value = getIntent().getExtras().getString(key);
+                Object value = getIntent().getExtras().get(key);
                 Log.d(TAG, "\tKey: " + key + " Value: " + value);
 				data.put(key, value);
             }


### PR DESCRIPTION
Fix the `ClassCastException` errors when try use `getExtras().getString()` in keys that contains **Long** or **Integer** values, like `google.ttl` and `google.sent_time` keys sent in Firebase _payload_.

Because these exceptions, the `onNotification()` in **Javascript** wasn't triggered when tap a notification received in a background app.

### Suggestion

Add a integration with [cordova-plugin-local-notifications](https://github.com/katzer/cordova-plugin-local-notifications) plugin, and execute the event **"click"** after `FCMPlugin.sendPushPayload(data);`

The code can be something like this:

```java
try {

    Class<?> plugin = Class.forName("LocalNotification");
    try {

        Method method = plugin.getMethod("fireEvent", String.class);

        try {
            method.invoke(null, "click");
        } catch (IllegalAccessException e) {
            e.printStackTrace();
        } catch (InvocationTargetException e) {
            e.printStackTrace();
        }
    } catch (NoSuchMethodException methodErr) {

    }
} catch (ClassNotFoundException classErr) {
    Log.w(TAG, "Plugin 'LocalNotification' is not installed! Don't trigger 'click' event");
}
```

What do you think about this?