### PR TITLE
Added hasPermission() for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,18 +50,10 @@ You can also test your notifications with the free testing server: https://cordo
 
 #### Checking for permissions (iOS only) - added in 3.0.1
 Copied from https://github.com/arnesson/cordova-plugin-firebase/blob/master/src/ios/FirebasePlugin.m#L68-L85
-```javascript
-//FCMPlugin.hasPermission( data );
-FCMPlugin.hasPermission(function(data){
-    alert( data.isEnabled );
-});
-```
 
 ```javascript
-//FCMPlugin.onTokenRefresh( onTokenRefreshCallback(token) );
-//Note that this callback will be fired everytime a new token is generated, including the first time.
-FCMPlugin.onTokenRefresh(function(token){
-    alert( token );
+FCMPlugin.hasPermission(function(data){
+    alert( data.isEnabled );
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,23 @@ Put the downloaded file 'GoogleService-Info.plist' in the Cordova project root f
 :warning: It's highly recommended to use REST API to send push notifications because Firebase console does not have all the functionalities. **Pay attention to the payload example in order to use the plugin properly**.  
 You can also test your notifications with the free testing server: https://cordova-plugin-fcm.appspot.com
 
+#### Checking for permissions (iOS only) - added in 3.0.1
+Copied from https://github.com/arnesson/cordova-plugin-firebase/blob/master/src/ios/FirebasePlugin.m#L68-L85
+```javascript
+//FCMPlugin.hasPermission( data );
+FCMPlugin.hasPermission(function(data){
+    alert( data.isEnabled );
+});
+```
+
+```javascript
+//FCMPlugin.onTokenRefresh( onTokenRefreshCallback(token) );
+//Note that this callback will be fired everytime a new token is generated, including the first time.
+FCMPlugin.onTokenRefresh(function(token){
+    alert( token );
+});
+```
+
 #### Receiving Token Refresh
 
 ```javascript

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "version": "3.0.0",
+  "version": "3.0.1",
   "name": "cordova-plugin-fcm-with-dependecy-updated",
   "cordova_name": "Cordova FCM Push Plugin",
-  "description": "Google Firebase Cloud Messaging Cordova Push Plugin fork with dependecy updated",
+  "description": "Google Firebase Cloud Messaging Cordova Push Plugin fork with dependecy updated, forked by Twisterking",
   "license": "MIT",
   "repo": "",
   "issue": "",

--- a/src/ios/FCMPlugin.h
+++ b/src/ios/FCMPlugin.h
@@ -8,6 +8,7 @@
 
 + (FCMPlugin *) fcmPlugin;
 - (void)ready:(CDVInvokedUrlCommand*)command;
+- (void)hasPermission:(CDVInvokedUrlCommand*)command;
 - (void)getToken:(CDVInvokedUrlCommand*)command;
 - (void)subscribeToTopic:(CDVInvokedUrlCommand*)command;
 - (void)unsubscribeFromTopic:(CDVInvokedUrlCommand*)command;

--- a/src/ios/FCMPlugin.m
+++ b/src/ios/FCMPlugin.m
@@ -37,6 +37,25 @@ static FCMPlugin *fcmPluginInstance;
     
 }
 
+// HAS PERMISSION //
+- (void) hasPermission:(CDVInvokedUrlCommand *)command
+{
+    BOOL enabled = NO;
+    UIApplication *application = [UIApplication sharedApplication];    
+    if ([[UIApplication sharedApplication] respondsToSelector:@selector(registerUserNotificationSettings:)]) {
+        enabled = application.currentUserNotificationSettings.types != UIUserNotificationTypeNone;
+    } else {
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+        enabled = application.enabledRemoteNotificationTypes != UIRemoteNotificationTypeNone;
+        #pragma GCC diagnostic pop
+    }    
+    NSMutableDictionary* message = [NSMutableDictionary dictionaryWithCapacity:1];
+    [message setObject:[NSNumber numberWithBool:enabled] forKey:@"isEnabled"];
+    CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:message];
+    [self.commandDelegate sendPluginResult:commandResult callbackId:command.callbackId];
+}
+
 // GET TOKEN //
 - (void) getToken:(CDVInvokedUrlCommand *)command 
 {

--- a/www/FCMPlugin.js
+++ b/www/FCMPlugin.js
@@ -4,6 +4,10 @@ function FCMPlugin() {
 	console.log("FCMPlugin.js: is created");
 }
 
+// iOS - CHECK FOR PERMISSION
+FCMPlugin.prototype.hasPermission = function( success, error ){
+  exec(success, error, "FCMPlugin", 'hasPermission', []);
+}
 // SUBSCRIBE TO TOPIC //
 FCMPlugin.prototype.subscribeToTopic = function( topic, success, error ){
 	exec(success, error, "FCMPlugin", 'subscribeToTopic', [topic]);


### PR DESCRIPTION
So I added a `hasPermission` functionality for iOS, so I can check in my code if the user has enabled Push Notifications on his iOS device.
Please note: **I am no iOS/Objective-C dev** - I just copied some code from another, outdated plugin and somehow get it to work!
It would be highly appreciated if someone with Objective-C skills checks my PR and maybe even improves on it.
This plugin otherwise is pretty much perfect, in my opinion it just lacked this functionality for iOS!