### PR TITLE
[Fix] Re-add firebase framework in ios podspect

### DIFF
--- a/cordova-plugin-fcm-with-dependecy-updated.podspec
+++ b/cordova-plugin-fcm-with-dependecy-updated.podspec
@@ -120,6 +120,16 @@ DESC
   #
 
   spec.frameworks  = "AddressBook", "Security", "UIKit"
+  spec.vendored_frameworks = [
+    "src/ios/firebase/FirebaseAnalytics.framework",
+    "src/ios/firebase/FirebaseCore.framework",
+    "src/ios/firebase/FirebaseInstanceID.framework",
+    "src/ios/firebase/FirebaseMessaging.framework",
+    "src/ios/firebase/GoogleInterchangeUtilities.framework",
+    "src/ios/firebase/GoogleIPhoneUtilities.framework",
+    "src/ios/firebase/GoogleSymbolUtilities.framework",
+    "src/ios/firebase/GoogleUtilities.framework"
+  ]
   # spec.framework  = "SomeFramework"
   # spec.frameworks = "SomeFramework", "AnotherFramework"
 


### PR DESCRIPTION
Is literally **impossible** to compile the v4.x.x on ios. Instead, the v3.2.0 still compiles and can run without problems, so I added the podspect changes that were different... but I'm afraid it would be missing to include the complete firebase library.

**Could you reproduce the plugin installation from a new project?**

On the other hand, and in addition, it was necessary to add the _User-Defined_ `PODS_PODFILE_DIR_PATH` and `PODS_ROOT` variables in _Bulid Settings_ for all versions. I suggest that it should at least be clarified in the README.md.  Could be:  
_Project → Build Settings → User-Defined → Add User-Defined Setting_
 - `PODS_PODFILE_DIR_PATH` = `${SRCROOT}`
 - `PODS_ROOT` = `${SRCROOT}/Pods`  

Moreover,  **are you sure that is a minimum requirement the `cordova-android>=8.0.0` and `cordova-ios>=5.0.0`?**