### PR TITLE
the meta-data configuration was added to set the default icon for firebase

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -53,6 +53,7 @@
 					<action android:name="com.google.firebase.MESSAGING_EVENT"/>
 				</intent-filter>
 			</service>
+			<meta-data android:name="com.google.firebase.messaging.default_notification_icon" android:resource="@drawable/fcm_push_icon" />
 		</config-file>
 		<config-file target="res/xml/config.xml" parent="/*">
 			<feature name="FCMPlugin">


### PR DESCRIPTION
Add the meta-data label with the default icon information specified for firebase, this way the blank icon of the application will no longer be displayed and the custom icon fcm_push_icon.png can be configured.

This has been proven for phonegap build cli-9.0.0