### PR TITLE
remove unnecessary android:exported="true" attribute from FCMPluginActivity in AndroidManifest.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -41,7 +41,7 @@
 		<preference name="ANDROID_DEFAULT_NOTIFICATION_ICON" default="@mipmap/ic_launcher" />
 
 		<config-file target="AndroidManifest.xml" parent="/manifest/application">
-			<activity android:exported="true" android:name="com.gae.scaffolder.plugin.FCMPluginActivity" android:launchMode="singleTop">
+			<activity android:name="com.gae.scaffolder.plugin.FCMPluginActivity" android:launchMode="singleTop">
 				<intent-filter>
 					<action android:name="FCM_PLUGIN_ACTIVITY" />
 					<category android:name="android.intent.category.DEFAULT" />


### PR DESCRIPTION
Removed android:exported="true" attribute from FCMPluginActivity in AndroidManifest.xml as it is unnecessary and a potential security risk, as it makes the activity startable from any external app, as it is not protected with an app defined permission.