### PR TITLE
chore: Add GoogleUtilities/UserDefaults to plugins

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -123,6 +123,7 @@
                 <source url="https://github.com/CocoaPods/Specs.git"/>
 			</config>
 			<pods>
+				<pod name="GoogleUtilities/UserDefaults" spec="~> 7.2.2"/>
 				<pod name="Firebase/Messaging" spec="$IOS_FIREBASE_MESSAGING_VERSION"/>
 			</pods>
 		</podspec>


### PR DESCRIPTION
Avoid building issues due to GoogleUtilities team removing old versions
that Firebase/Messaging rely on.

The google utilities repo dropped old versions which, depending on the user-defined version in IOS_FIREBASE_MESSAGING_VERSION, can make the plugin not work for iOS https://github.com/google/GoogleUtilities/tags