### PR TITLE
Improvement: Adding new url in order to bring support for "trunk specs repo" in CocoaPods

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -123,8 +123,7 @@
                 <source url="https://cdn.cocoapods.org/"/>
 			</config>
 			<pods>
-				<pod name="GoogleUtilities/UserDefaults" spec="~> 7.2.2"/>
-				<pod name="Firebase/Messaging" spec="~> 7.4.0"/>
+				<pod name="Firebase/Messaging"/>
 			</pods>
 		</podspec>
 	</platform>

--- a/plugin.xml
+++ b/plugin.xml
@@ -120,9 +120,10 @@
 		<!-- FIREBASE COCOAPODS-->
 		<podspec>
 			<config>
-                <source url="https://github.com/CocoaPods/Specs.git"/>
+                <source url="https://cdn.cocoapods.org/"/>
 			</config>
 			<pods>
+				<pod name="GoogleUtilities/UserDefaults" spec="~> 7.2.2"/>
 				<pod name="Firebase/Messaging" spec="$IOS_FIREBASE_MESSAGING_VERSION"/>
 			</pods>
 		</podspec>

--- a/plugin.xml
+++ b/plugin.xml
@@ -124,7 +124,7 @@
 			</config>
 			<pods>
 				<pod name="GoogleUtilities/UserDefaults" spec="~> 7.2.2"/>
-				<pod name="Firebase/Messaging" spec="$IOS_FIREBASE_MESSAGING_VERSION"/>
+				<pod name="Firebase/Messaging" spec="~> 7.4.0"/>
 			</pods>
 		</podspec>
 	</platform>


### PR DESCRIPTION
According to one of the latest update from CocoaPod, the new repo is pointing now to a **CDN** adding support for [trunk specs repo.](https://github.com/CocoaPods/Specs).

Source: [https://blog.cocoapods.org/CocoaPods-1.7.2/](https://blog.cocoapods.org/CocoaPods-1.7.2/) 

This change allows us to use this amazing cordova plugin with others updated plugins such like [cordova-plugin-googleplus](https://github.com/EddyVerbruggen/cordova-plugin-googleplus)

Also, the `Firebase/Messaging` version is now handled by the GoogleUtilities package. 
