### PR TITLE
Move value of IOS_FIREBASE_MESSAGING_VERSION in plugin.xml directly t…

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -80,7 +80,6 @@
 
 	<!-- IOS CONFIGURATION -->
 	<platform name="ios">
-		<preference name="IOS_FIREBASE_MESSAGING_VERSION" default="~> 7.4.0" />
 		<config-file target="config.xml" parent="/*">
 			<feature name="FCMPlugin">
 				<param name="ios-package" value="FCMPlugin"/>
@@ -123,7 +122,7 @@
                 <source url="https://github.com/CocoaPods/Specs.git"/>
 			</config>
 			<pods>
-				<pod name="Firebase/Messaging" spec="$IOS_FIREBASE_MESSAGING_VERSION"/>
+				<pod name="Firebase/Messaging" spec="~> 7.4.0"/>
 			</pods>
 		</podspec>
 	</platform>


### PR DESCRIPTION
The pod installation for >7.5.0 fails with:
`Argument Error: Illformed requirement "$IOS_FIREBASE_MESSAGING_VERSION"`

The cause seems to be, that the "<preference" value in line 83 is not recognized as an ENV variable.

Therefore I moved the value `"~> 7.4.0"` directly to the pod specification which solves the problem for me, which solves the problem for me.