### PR TITLE
Support for Android SDK 31

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Make sure you have ‘google-services.json’ for Android and/or ‘GoogleServic
 |Preference|Default Value|Description|
 |---|---|---|
 |ANDROID_DEFAULT_NOTIFICATION_ICON|@mipmap/ic_launcher|Default notification icon.|
-|ANDROID_FCM_VERSION|21.0.0|Native Firebase Message SDK version.<br>:warning: Replaced by BoM versioning on Gradle >= 3.4.|
-|ANDROID_FIREBASE_BOM_VERSION|26.0.0|[Firebase BoM](https://firebase.google.com/docs/android/learn-more#bom) version.|
+|ANDROID_FCM_VERSION|23.0.0|Native Firebase Message SDK version.<br>:warning: Replaced by BoM versioning on Gradle >= 3.4.|
+|ANDROID_FIREBASE_BOM_VERSION|29.0.1|[Firebase BoM](https://firebase.google.com/docs/android/learn-more#bom) version.|
 |ANDROID_GOOGLE_SERVICES_VERSION|4.3.4|Native Google Services SDK version.|
 |ANDROID_GRADLE_TOOLS_VERSION|4.1.0|Gradle tools version.|
 |IOS_FIREBASE_MESSAGING_VERSION|~> 7.4.0|Native Firebase Message SDK version|

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 [![npm version](https://img.shields.io/npm/v/cordova-plugin-fcm-with-dependecy-updated.svg)](https://www.npmjs.com/package/cordova-plugin-fcm-with-dependecy-updated)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![GitHub issues](https://img.shields.io/github/issues/andrehtissot/cordova-plugin-fcm-with-dependecy-updated.svg)](https://github.com/andrehtissot/cordova-plugin-fcm-with-dependecy-updated/issues)
-[![GitHub forks](https://img.shields.io/github/forks/andrehtissot/cordova-plugin-fcm-with-dependecy-updated.svg)](https://github.com/andrehtissot/cordova-plugin-fcm-with-dependecy-updated/network)
-[![GitHub stars](https://img.shields.io/github/stars/andrehtissot/cordova-plugin-fcm-with-dependecy-updated.svg)](https://github.com/andrehtissot/cordova-plugin-fcm-with-dependecy-updated/stargazers)
+[![GitHub forks](https://img.shields.io/github/forks/andrehtissot/cordova-plugin-fcm-with-dependecy-updated.svg)](https://github.com/marutifh/cordova-plugin-fcm-with-dependecy-updated/network)
+[![GitHub stars](https://img.shields.io/github/stars/andrehtissot/cordova-plugin-fcm-with-dependecy-updated.svg)](https://github.com/marutifh/cordova-plugin-fcm-with-dependecy-updated/stargazers)
 [![Known Vulnerabilities](https://snyk.io/test/github/andrehtissot/cordova-plugin-fcm-with-dependecy-updated/badge.svg?targetFile=package.json)](https://snyk.io/test/github/andrehtissot/cordova-plugin-fcm-with-dependecy-updated?targetFile=package.json)
 [![DeepScan grade](https://deepscan.io/api/teams/3417/projects/5068/branches/39495/badge/grade.svg)](https://deepscan.io/dashboard#view=project&tid=3417&pid=5068&bid=39495)
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -37,7 +37,6 @@
 	<platform name="android">
 		<preference name="ANDROID_DEFAULT_NOTIFICATION_ICON" default="@mipmap/ic_launcher" />
 		<preference name="ANDROID_FCM_VERSION" default="23.0.0" />
-		<preference name="ANDROID_FIREBASE_IID_VERSION" default="21.1.0" />
 		<preference name="ANDROID_FIREBASE_BOM_VERSION" default="29.0.1" />
 		<preference name="ANDROID_GOOGLE_SERVICES_VERSION" default="4.3.4" />
 		<preference name="ANDROID_GRADLE_TOOLS_VERSION" default="4.1.0" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -37,6 +37,7 @@
 	<platform name="android">
 		<preference name="ANDROID_DEFAULT_NOTIFICATION_ICON" default="@mipmap/ic_launcher" />
 		<preference name="ANDROID_FCM_VERSION" default="23.0.0" />
+		<preference name="ANDROID_FIREBASE_IID_VERSION" default="21.1.0" />
 		<preference name="ANDROID_FIREBASE_BOM_VERSION" default="29.0.1" />
 		<preference name="ANDROID_GOOGLE_SERVICES_VERSION" default="4.3.4" />
 		<preference name="ANDROID_GRADLE_TOOLS_VERSION" default="4.1.0" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -36,8 +36,8 @@
 	<!-- ANDROID CONFIGURATION -->
 	<platform name="android">
 		<preference name="ANDROID_DEFAULT_NOTIFICATION_ICON" default="@mipmap/ic_launcher" />
-		<preference name="ANDROID_FCM_VERSION" default="23.0.8" />
-		<preference name="ANDROID_FIREBASE_BOM_VERSION" default="30.5.0" />
+		<preference name="ANDROID_FCM_VERSION" default="23.0.0" />
+		<preference name="ANDROID_FIREBASE_BOM_VERSION" default="29.0.1" />
 		<preference name="ANDROID_GOOGLE_SERVICES_VERSION" default="4.3.4" />
 		<preference name="ANDROID_GRADLE_TOOLS_VERSION" default="4.1.0" />
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -36,8 +36,8 @@
 	<!-- ANDROID CONFIGURATION -->
 	<platform name="android">
 		<preference name="ANDROID_DEFAULT_NOTIFICATION_ICON" default="@mipmap/ic_launcher" />
-		<preference name="ANDROID_FCM_VERSION" default="21.0.0" />
-		<preference name="ANDROID_FIREBASE_BOM_VERSION" default="26.0.0" />
+		<preference name="ANDROID_FCM_VERSION" default="23.0.8" />
+		<preference name="ANDROID_FIREBASE_BOM_VERSION" default="30.5.0" />
 		<preference name="ANDROID_GOOGLE_SERVICES_VERSION" default="4.3.4" />
 		<preference name="ANDROID_GRADLE_TOOLS_VERSION" default="4.1.0" />
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -42,7 +42,7 @@
 		<preference name="ANDROID_GRADLE_TOOLS_VERSION" default="4.1.0" />
 
 		<config-file target="AndroidManifest.xml" parent="/manifest/application">
-			<activity android:name="com.gae.scaffolder.plugin.FCMPluginActivity" android:launchMode="singleTop">
+			<activity android:name="com.gae.scaffolder.plugin.FCMPluginActivity" android:exported="false" android:launchMode="singleTop">
 				<intent-filter>
 					<action android:name="FCM_PLUGIN_ACTIVITY" />
 					<category android:name="android.intent.category.DEFAULT" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -49,7 +49,8 @@
 				</intent-filter>
 			</activity>
 			<service 
-				android:name="com.gae.scaffolder.plugin.MyFirebaseMessagingService"
+				android:name="com.gae.scaffolder.plugin.MyFirebaseMessagingService" 
+				android:exported="false" 
 				android:stopWithTask="false">
 				<intent-filter>
 					<action android:name="com.google.firebase.MESSAGING_EVENT"/>

--- a/plugin.xml
+++ b/plugin.xml
@@ -42,7 +42,7 @@
 		<preference name="ANDROID_GRADLE_TOOLS_VERSION" default="4.1.0" />
 
 		<config-file target="AndroidManifest.xml" parent="/manifest/application">
-			<activity android:name="com.gae.scaffolder.plugin.FCMPluginActivity" android:exported="false" android:launchMode="singleTop">
+			<activity android:name="com.gae.scaffolder.plugin.FCMPluginActivity" android:exported="true" android:launchMode="singleTop">
 				<intent-filter>
 					<action android:name="FCM_PLUGIN_ACTIVITY" />
 					<category android:name="android.intent.category.DEFAULT" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -36,7 +36,7 @@
 	<!-- ANDROID CONFIGURATION -->
 	<platform name="android">
 		<preference name="ANDROID_DEFAULT_NOTIFICATION_ICON" default="@mipmap/ic_launcher" />
-		<preference name="ANDROID_FCM_VERSION" default="23.0.0" />
+		<preference name="ANDROID_FCM_VERSION" default="23.0.8" />
 		<preference name="ANDROID_FIREBASE_BOM_VERSION" default="29.0.1" />
 		<preference name="ANDROID_GOOGLE_SERVICES_VERSION" default="4.3.4" />
 		<preference name="ANDROID_GRADLE_TOOLS_VERSION" default="4.1.0" />

--- a/src/android/com/gae/scaffolder/plugin/FCMPlugin.java
+++ b/src/android/com/gae/scaffolder/plugin/FCMPlugin.java
@@ -271,12 +271,17 @@ public class FCMPlugin extends CordovaPlugin {
                 try {
                     if (Build.VERSION.SDK_INT >= 33) { // Android 13+
                         boolean hasRuntimePermission = hasRuntimePermission(POST_NOTIFICATIONS);
-                        if (!hasRuntimePermission) {
+                        if (hasRuntimePermission) {
+                            callbackContext.success(1);
+                        }
+                        else {
                             String[] permissions = new String[]{qualifyPermission(POST_NOTIFICATIONS)};
                             postNotificationPermissionRequestCallbackContext = callbackContext;
                             requestPermissions(plugin, POST_NOTIFICATIONS_PERMISSION_REQUEST_ID, permissions);
                             sendEmptyPluginResultAndKeepCallback(callbackContext);
                         }
+                    } else {
+                        callbackContext.success(1);
                     }
 
                 } catch (Exception e) {

--- a/src/android/com/gae/scaffolder/plugin/FCMPlugin.java
+++ b/src/android/com/gae/scaffolder/plugin/FCMPlugin.java
@@ -9,7 +9,6 @@ import com.gae.scaffolder.plugin.interfaces.*;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.Task;
-import com.google.firebase.iid.InstanceIdResult;
 import com.google.firebase.messaging.FirebaseMessaging;
 
 import org.apache.cordova.CallbackContext;
@@ -178,9 +177,9 @@ public class FCMPlugin extends CordovaPlugin {
 
     public void getToken(final TokenListeners<String, JSONObject> callback) {
         try {
-            FirebaseMessaging.getInstance().getInstanceId().addOnCompleteListener(new OnCompleteListener<InstanceIdResult>() {
+            FirebaseMessaging.getInstance().getToken().addOnCompleteListener(new OnCompleteListener<String>() {
                 @Override
-                public void onComplete(Task<InstanceIdResult> task) {
+                public void onComplete(Task<String> task) {
                     if (!task.isSuccessful()) {
                         Log.w(TAG, "getInstanceId failed", task.getException());
                         try {
@@ -193,14 +192,14 @@ public class FCMPlugin extends CordovaPlugin {
                     }
 
                     // Get new Instance ID token
-                    String newToken = task.getResult().getToken();
+                    String newToken = task.getResult();
 
                     Log.i(TAG, "\tToken: " + newToken);
                     callback.success(newToken);
                 }
             });
 
-            FirebaseMessaging.getInstance().getInstanceId().addOnFailureListener(new OnFailureListener() {
+            FirebaseMessaging.getInstance().getToken().addOnFailureListener(new OnFailureListener() {
                 @Override
                 public void onFailure(final Exception e) {
                     try {
@@ -223,7 +222,7 @@ public class FCMPlugin extends CordovaPlugin {
         cordova.getThreadPool().execute(new Runnable() {
             public void run() {
                 try {
-                    FirebaseMessaging.getInstance().deleteInstanceId();
+                    FirebaseMessaging.getInstance().deleteToken();
                     callbackContext.success();
                 } catch (Exception e) {
                     callbackContext.error(e.getMessage());

--- a/src/android/com/gae/scaffolder/plugin/FCMPlugin.java
+++ b/src/android/com/gae/scaffolder/plugin/FCMPlugin.java
@@ -9,7 +9,6 @@ import com.gae.scaffolder.plugin.interfaces.*;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.Task;
-import com.google.firebase.iid.FirebaseInstanceId;
 import com.google.firebase.iid.InstanceIdResult;
 import com.google.firebase.messaging.FirebaseMessaging;
 
@@ -179,7 +178,7 @@ public class FCMPlugin extends CordovaPlugin {
 
     public void getToken(final TokenListeners<String, JSONObject> callback) {
         try {
-            FirebaseInstanceId.getInstance().getInstanceId().addOnCompleteListener(new OnCompleteListener<InstanceIdResult>() {
+            FirebaseMessaging.getInstance().getInstanceId().addOnCompleteListener(new OnCompleteListener<InstanceIdResult>() {
                 @Override
                 public void onComplete(Task<InstanceIdResult> task) {
                     if (!task.isSuccessful()) {
@@ -201,7 +200,7 @@ public class FCMPlugin extends CordovaPlugin {
                 }
             });
 
-            FirebaseInstanceId.getInstance().getInstanceId().addOnFailureListener(new OnFailureListener() {
+            FirebaseMessaging.getInstance().getInstanceId().addOnFailureListener(new OnFailureListener() {
                 @Override
                 public void onFailure(final Exception e) {
                     try {
@@ -224,7 +223,7 @@ public class FCMPlugin extends CordovaPlugin {
         cordova.getThreadPool().execute(new Runnable() {
             public void run() {
                 try {
-                    FirebaseInstanceId.getInstance().deleteInstanceId();
+                    FirebaseMessaging.getInstance().deleteInstanceId();
                     callbackContext.success();
                 } catch (Exception e) {
                     callbackContext.error(e.getMessage());

--- a/src/android/com/gae/scaffolder/plugin/FCMPlugin.java
+++ b/src/android/com/gae/scaffolder/plugin/FCMPlugin.java
@@ -271,7 +271,10 @@ public class FCMPlugin extends CordovaPlugin {
                 try {
                     if (Build.VERSION.SDK_INT >= 33) { // Android 13+
                         boolean hasRuntimePermission = hasRuntimePermission(POST_NOTIFICATIONS);
-                        if (!hasRuntimePermission) {
+                        if (hasRuntimePermission) {
+                            callbackContext.success(1);
+                        }
+                        else {
                             String[] permissions = new String[]{qualifyPermission(POST_NOTIFICATIONS)};
                             postNotificationPermissionRequestCallbackContext = callbackContext;
                             requestPermissions(plugin, POST_NOTIFICATIONS_PERMISSION_REQUEST_ID, permissions);

--- a/www/FCMPlugin.js
+++ b/www/FCMPlugin.js
@@ -80,9 +80,6 @@ var FCMPlugin = (function () {
     };
     FCMPlugin.prototype.requestPushPermission = function (options) {
         var _a, _b, _c, _d;
-        if (window.cordova.platformId !== 'ios') {
-            return Promise.resolve(true);
-        }
         var ios9SupportTimeout = (_b = (_a = options === null || options === void 0 ? void 0 : options.ios9Support) === null || _a === void 0 ? void 0 : _a.timeout) !== null && _b !== void 0 ? _b : 10;
         var ios9SupportInterval = (_d = (_c = options === null || options === void 0 ? void 0 : options.ios9Support) === null || _c === void 0 ? void 0 : _c.interval) !== null && _d !== void 0 ? _d : 0.3;
         return execAsPromise('requestPushPermission', [ios9SupportTimeout, ios9SupportInterval]);


### PR DESCRIPTION
Hi, 

When we set target SDK to 31, it gives a compile time error, so added fix for this. 

Error observed

`Manifest merger failed : Apps targeting Android 12 and higher are required to specify an explicit value for `android:exported` when the corresponding component has an intent filter defined. See https://developer.android.
com/guide/topics/manifest/activity-element#exported for details.`