### PR TITLE
Update plugin.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Default preferences:
 ```sh
 npm install -g cordova@latest # Version 9 or higher required
 npm uninstall @ionic-native/fcm # Ionic support is included and conflicts with @ionic-native's implementation.
-cordova plugin add cordova-plugin-fcm-with-dependecy-updated
+cordova plugin add cordova-plugin-fcm-with-dependecy-updated-12
 ```
 
 Complete:

--- a/plugin.xml
+++ b/plugin.xml
@@ -42,13 +42,14 @@
 		<preference name="ANDROID_GRADLE_TOOLS_VERSION" default="4.1.0" />
 
 		<config-file target="AndroidManifest.xml" parent="/manifest/application">
-			<activity android:name="com.gae.scaffolder.plugin.FCMPluginActivity" android:launchMode="singleTop">
+			<activity android:exported="true" android:name="com.gae.scaffolder.plugin.FCMPluginActivity" android:launchMode="singleTop">
 				<intent-filter>
 					<action android:name="FCM_PLUGIN_ACTIVITY" />
 					<category android:name="android.intent.category.DEFAULT" />
 				</intent-filter>
 			</activity>
 			<service 
+				android:exported="true"
 				android:name="com.gae.scaffolder.plugin.MyFirebaseMessagingService"
 				android:stopWithTask="false">
 				<intent-filter>


### PR DESCRIPTION
Apps targeting Android 12 and higher are required to specify an explicit value for `android:exported` when the corresponding component has an intent filter defined.